### PR TITLE
Add dark mode theme with toggle switch

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,6 +19,14 @@
 
 
 <body>
+  <div class="theme-toggle">
+    <span class="theme-icon">&#9728;</span>
+    <label class="switch">
+      <input type="checkbox" id="theme-toggle">
+      <span class="slider"></span>
+    </label>
+    <span class="theme-icon">&#9790;</span>
+  </div>
   <table style="width:100%;max-width:800px;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;">
     <tr style="padding:0px">
       <td style="padding:0px">
@@ -118,6 +126,23 @@
       </td>
     </tr>
   </table>
+  <script>
+    const toggle = document.getElementById('theme-toggle');
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'dark') {
+      document.body.classList.add('dark-mode');
+      toggle.checked = true;
+    }
+    toggle.addEventListener('change', function () {
+      if (this.checked) {
+        document.body.classList.add('dark-mode');
+        localStorage.setItem('theme', 'dark');
+      } else {
+        document.body.classList.remove('dark-mode');
+        localStorage.setItem('theme', 'light');
+      }
+    });
+  </script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,14 @@
 
 
 <body>
+  <div class="theme-toggle">
+    <span class="theme-icon">&#9728;</span>
+    <label class="switch">
+      <input type="checkbox" id="theme-toggle">
+      <span class="slider"></span>
+    </label>
+    <span class="theme-icon">&#9790;</span>
+  </div>
   <table style="width:100%;max-width:800px;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;">
     <tr style="padding:0px">
       <td style="padding:0px">
@@ -199,6 +207,23 @@
       </td>
     </tr>
   </table>
+  <script>
+    const toggle = document.getElementById('theme-toggle');
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'dark') {
+      document.body.classList.add('dark-mode');
+      toggle.checked = true;
+    }
+    toggle.addEventListener('change', function () {
+      if (this.checked) {
+        document.body.classList.add('dark-mode');
+        localStorage.setItem('theme', 'dark');
+      } else {
+        document.body.classList.remove('dark-mode');
+        localStorage.setItem('theme', 'light');
+      }
+    });
+  </script>
 </body>
 
 </html>

--- a/style.scss
+++ b/style.scss
@@ -12,14 +12,26 @@
 /**************/
 /* BASE RULES */
 /**************/
+:root {
+  --bg-color: #fff;
+  --text-color: #000;
+  --link-color: #1772d0;
+  --link-hover-color: #f09228;
+  --highlight-color: #ffffd0;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
 a {
-  color: #1772d0;
+  color: var(--link-color);
   text-decoration: none;
 }
 
 a:focus,
 a:hover {
-  color: #f09228;
+  color: var(--link-hover-color);
   text-decoration: none;
 }
 
@@ -96,7 +108,84 @@ h1 {
 }
 
 span.highlight {
-  background-color: #ffffd0;
+  background-color: var(--highlight-color);
+}
+
+/* Dark mode variables */
+body.dark-mode {
+  --bg-color: #1e1e1e;
+  --text-color: #e0e0e0;
+  --link-color: #9bbcff;
+  --link-hover-color: #f5b75c;
+  --highlight-color: #333a3a;
+}
+
+/* Toggle switch */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: 0.4s;
+  border-radius: 34px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 14px;
+  width: 14px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: 0.4s;
+  border-radius: 50%;
+}
+
+input:checked + .slider {
+  background-color: #2196f3;
+}
+
+input:checked + .slider:before {
+  transform: translateX(20px);
+}
+
+/* Toggle wrapper positioning and icons */
+.theme-toggle {
+  position: fixed;
+  top: 50%;
+  right: calc((100vw - 800px) / 2);
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  z-index: 1000;
+}
+
+@media (max-width: 800px) {
+  .theme-toggle {
+    right: 10px;
+  }
+}
+
+.theme-icon {
+  font-size: 16px;
 }
 
 // Settled on moving the import of syntax highlighting to the bottom of the CSS


### PR DESCRIPTION
## Summary
- add CSS variables and dark mode styles with toggle switch styling
- include a dark mode toggle and persistence script in index and default layout
- position toggle at center-right and add sun/moon icons for mode indication

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_6897b589a1f08320949b0984bc4ed10e